### PR TITLE
Fixes .gitignore to include sass cache + more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+.sass-cache
+bower_components
+.DS_Store


### PR DESCRIPTION
Refined .gitignore to include sass cache and bower dependencies

@jeffreymendez1993 Please review this pull request and get it into master and your team working with it asap to avoid bloating your repo with dependencies and cache files.
